### PR TITLE
Added support for DTL-H1202 (Green PAL Debugging Station)

### DIFF
--- a/secondary.c
+++ b/secondary.c
@@ -179,6 +179,10 @@ bool unlock_drive() {
 	} else if (strcmp((char *) cd_reply, "for NETNA") == 0) {
 		region_name = "NetYaroze (US)";
 		p5_localized = "World wide";
+	} else if (strcmp((char *) cd_reply, "for US/AEP") == 0) { /* DTL-H1202 */
+		region_name = "Debug 2.2 (EU)";
+		p5_localized = "DONTCARE";	
+	}
 	} else {
 		// +4 to skip past "for "
 		debug_write("Unsup. region: %s", (char *) (cd_reply + 4));

--- a/secondary.c
+++ b/secondary.c
@@ -182,7 +182,6 @@ bool unlock_drive() {
 	} else if (strcmp((char *) cd_reply, "for US/AEP") == 0) { /* DTL-H1202 */
 		region_name = "Debug 2.2 (EU)";
 		p5_localized = "DONTCARE";	
-	}
 	} else {
 		// +4 to skip past "for "
 		debug_write("Unsup. region: %s", (char *) (cd_reply + 4));

--- a/secondary.c
+++ b/secondary.c
@@ -179,7 +179,7 @@ bool unlock_drive() {
 	} else if (strcmp((char *) cd_reply, "for NETNA") == 0) {
 		region_name = "NetYaroze (US)";
 		p5_localized = "World wide";
-	else if (strcmp((char *) cd_reply, "for US/AEP") == 0) { /* DTL-H1202 */
+	} else if (strcmp((char *) cd_reply, "for US/AEP") == 0) { /* DTL-H1202 */
 		region_name = "Debug 2.2 (EU)";
 		p5_localized = "DONTCARE";
 	} else {

--- a/secondary.c
+++ b/secondary.c
@@ -179,9 +179,9 @@ bool unlock_drive() {
 	} else if (strcmp((char *) cd_reply, "for NETNA") == 0) {
 		region_name = "NetYaroze (US)";
 		p5_localized = "World wide";
-	} else if (strcmp((char *) cd_reply, "for US/AEP") == 0) { /* DTL-H1202 */
+	else if (strcmp((char *) cd_reply, "for US/AEP") == 0) { /* DTL-H1202 */
 		region_name = "Debug 2.2 (EU)";
-		p5_localized = "DONTCARE";	
+		p5_localized = "DONTCARE";
 	} else {
 		// +4 to skip past "for "
 		debug_write("Unsup. region: %s", (char *) (cd_reply + 4));


### PR DESCRIPTION
Just a suggestion: I have added an IF for the Green PAL Debugging Station where the cd reply is "for US/AEP".

In the end it is useless, because the cdrom drive is already unlocked, but this way it don't end up in the ELSE for the unsupported regions and it will show the "SWAP CD" message and act normally. 

Successfully tested on a real DTL-H1202.