### PR TITLE
Setup dev. env. with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+from ubuntu:jammy
+
+# build dependencies
+RUN apt-get update
+RUN apt-get install -y build-essential gcc-mips-linux-gnu cmake libtinyxml2-dev git zip
+
+# download, compile and install mkpsxiso
+RUN git clone https://github.com/Lameguy64/mkpsxiso/
+WORKDIR mkpsxiso
+RUN git submodule update --init --recursive
+RUN cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build ./build \
+    && cmake --install ./build
+
+WORKDIR /
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Working with my Mac I had a hard time trying to setup myself to begin the development of https://github.com/socram8888/tonyhax/issues/75

I followed the `Development` intructions at https://orca.pet/tonyhax/ as well as the `Compiling` instructions from https://github.com/Lameguy64/mkpsxiso#compiling.

I got an error with the `gcc-10-mips-linux-gnu` package not providing the `mips-linux-gnu-gcc` CLI which I fixed (and you should probably too in the aformentioned doc) with installing `gcc-mips-linux-gnu` instead.

## Usage

Basically you clone the tonyhax repo. Then once inside the dir you have to build the docker image with,

```sh
docker build -t tonyhax-dev .
```

Now that you have the image, you can compile tonyhax by booting a container,

```sh
docker run -v $(pwd):/tonyhax -it tonyhax-dev
```

And then `make`,

```sh
cd tonyhax/
make
```

The zip file will appear at the root of the host directory (outside the container) 🎉 